### PR TITLE
feat: user/index에 rkt query 적용

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -27,6 +27,7 @@ module.exports = {
     "prettier", //disable all ESLint rules that collides with prettier
   ],
   rules: {
+    "@typescript-eslint/no-misused-promises": "off",
     "import/order": [
       "warn",
       {

--- a/functions/rtkQueryErrorLog.ts
+++ b/functions/rtkQueryErrorLog.ts
@@ -1,0 +1,12 @@
+import { SerializedError } from "@reduxjs/toolkit";
+import { FetchBaseQueryError } from "@reduxjs/toolkit/dist/query";
+
+export const rtkQueryErrorLog = (
+  error: FetchBaseQueryError | SerializedError | undefined,
+) => {
+  if (error && "status" in error) {
+    // you can access all properties of `FetchBaseQueryError` here
+    const errMsg = "error" in error ? error.error : JSON.stringify(error.data);
+    console.log(errMsg);
+  }
+};

--- a/modules/api/api.ts
+++ b/modules/api/api.ts
@@ -5,10 +5,8 @@ import {
   fetchBaseQuery,
   FetchBaseQueryError,
 } from "@reduxjs/toolkit/query/react";
-import { HYDRATE } from "next-redux-wrapper";
 import { TokensType } from "../../api/api";
 import { manageTokens } from "../../functions/auth";
-import { UserDataType, UserPutType } from "../../types/types";
 import { signOut } from "../auth";
 
 const baseQuery = fetchBaseQuery({

--- a/modules/api/usersApi.ts
+++ b/modules/api/usersApi.ts
@@ -1,22 +1,22 @@
 import { UserDataType, UserPutType } from "../../types/types";
 import { api } from "./api";
 
-const usersApi = api.injectEndpoints({
+export const usersApi = api.injectEndpoints({
   endpoints: (build) => ({
     getMe: build.query<UserDataType, void>({
       query: () => ({ url: "/users/me/" }),
       providesTags: [{ type: "Users/me" }],
     }),
     putMe: build.mutation<UserDataType, UserPutType>({
-      query: () => ({ url: "/users/me/" }),
+      query: (body) => ({ method: "PUT", url: "/users/me/", body }),
       invalidatesTags: [{ type: "Users/me" }],
     }),
-    deleteMe: build.mutation<UserDataType, UserPutType>({
-      query: () => ({ url: "/users/me/" }),
+    deleteMe: build.mutation<UserDataType, void>({
+      query: () => ({ method: "DELETE", url: "/users/me/" }),
       invalidatesTags: [{ type: "Users/me" }],
     }),
     getUser: build.query<UserDataType, number>({
-      query: (id) => ({ url: `/users/me/${id}` }),
+      query: (body) => ({ url: `/users/me/${body}` }),
       providesTags: (result) => [{ type: "Users/other", id: result?.user_id }],
     }),
   }),

--- a/modules/index.ts
+++ b/modules/index.ts
@@ -27,7 +27,7 @@ export const store = () =>
       auth,
       canvasRef,
       modal,
-      pixiGraphics,
+      //   pixiGraphics,
       staticObjects,
       user,
       ws,

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -6,19 +6,21 @@ import { ACCESS_TOKEN_KEY } from "../functions/auth";
 import { wrapper } from "../modules";
 import "../styles/globals.scss";
 import { signIn, signOut } from "../modules/auth";
+import { setUser } from "../modules/user";
+import { initiateWebSocket } from "../api/websocket";
 
 const MyApp = ({ Component, pageProps }: AppProps) => {
   const dispatch = useDispatch();
 
   const checkAuth = async () => {
     const accessToken = localStorage.getItem(ACCESS_TOKEN_KEY);
-
     if (accessToken) {
       authInstance.defaults.headers.common[
         "Authorization"
       ] = `Bearer ${accessToken}`;
       try {
-        await api._getme();
+        const { data } = await api._getme();
+        dispatch(setUser(data));
         dispatch(signIn());
       } catch (e) {
         console.log(e);


### PR DESCRIPTION
`pages/user/index` 파일을 좀 바꿨습니다.
- putMe, deleteMe, getUser: rtk query hook, initiate() 사용
- input onChange handler는 하나로
- rtk query error는 rtkQueryErrorLog()로(rtk query 문서 [참고](https://redux-toolkit.js.org/rtk-query/usage/error-handling))
- 초기 username, email은 input value에 바로 넣어두었습니다
- getUser의 경우 hook을 사용하지 않고 initiate() 사용 - hook을 처음에 사용할 때 id를 넣어줘야 하기 때문
  - 나중에 필요하면 ...endpoints.getUser.useQueryState(id) 같은 식으로 데이터 접근해서 쓰면 될 것 같습니다